### PR TITLE
Bugfixing.

### DIFF
--- a/BWWalkthrough/BWWalkthroughPageViewController.cs
+++ b/BWWalkthrough/BWWalkthroughPageViewController.cs
@@ -39,10 +39,10 @@ namespace BWWalkthrough
 		} = new CGPoint(0, 0);
 
 		[Export("AnimationType"), Browsable(true)]
-		public String AnimationType
+		public string AnimationType
 		{
-			get { return this.AnimationType.ToString(); }
-			set { this.AnimationType = value; }
+			get { return this.animation.ToString(); }
+			set { this.animation = (WalkthroughAnimationType)Enum.Parse(typeof(WalkthroughAnimationType), value); }
 		}
 
 		[Export("AnimateAlpha"), Browsable(true)]

--- a/sample/sample/sample.csproj
+++ b/sample/sample/sample.csproj
@@ -133,8 +133,5 @@
       <Name>BWWalkthrough</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <BundleResource Include="Resources\.DS_Store" />
-  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>


### PR DESCRIPTION
- **BWWalkthroughPageViewController.cs**:
  Fixed recursive call to AnimationType property.
  The original Swift code uses this property to convert a string to/from the WalkthroughAnimationType enum.
- **sample.csproj**:
  Removed spurious reference to .DS_Store.
